### PR TITLE
replace openssl by cryptohash

### DIFF
--- a/Combinatorrent.cabal
+++ b/Combinatorrent.cabal
@@ -69,7 +69,7 @@ executable Combinatorrent
     deepseq,
     directory,
     filepath,
-    hopenssl,
+    cryptohash,
     hslogger,
     HTTP,
     HUnit,

--- a/src/Digest.hs
+++ b/src/Digest.hs
@@ -17,29 +17,15 @@ import Foreign.Ptr
 import qualified Data.ByteString as B
 import Data.ByteString.Unsafe
 import qualified Data.ByteString.Lazy as L
-import qualified OpenSSL.Digest as SSL
+import qualified Crypto.Hash.SHA1 as SHA1
 
 -- Consider newtyping this
 type Digest = B.ByteString
 
 instance NFData Digest
 
-digest :: L.ByteString -> IO B.ByteString
-digest bs = {-# SCC "sha1_digest" #-} B.pack <$> digestLBS SSL.SHA1 bs
+digest :: L.ByteString -> B.ByteString
+digest bs = {-# SCC "sha1_digest" #-} SHA1.hashlazy bs
 
-digestBS :: B.ByteString -> IO B.ByteString
+digestBS :: B.ByteString -> B.ByteString
 digestBS bs = digest . L.fromChunks $ [bs]
-
-digestLBS :: SSL.MessageDigest -> L.ByteString -> IO [Word8]
-digestLBS mdType xs = SSL.mkDigest mdType $ evalStateT (updateLBS xs >> SSL.final)
-
-updateBS :: B.ByteString -> SSL.Digest ()
-updateBS bs = do
-    SSL.DST ctx <- get
-    _ <- liftIO $ unsafeUseAsCStringLen bs $
-            \(ptr, len) -> SSL.digestUpdate ctx (castPtr ptr) (fromIntegral len)
-    return ()
-
-updateLBS :: L.ByteString -> SSL.Digest ()
-updateLBS lbs = mapM_ updateBS chunked
-  where chunked = {-# SCC "sha1_updateLBS_chunked" #-} L.toChunks lbs

--- a/src/FS.hs
+++ b/src/FS.hs
@@ -136,8 +136,7 @@ checkPiece inf handles = {-# SCC "checkPiece" #-} do
                       do hSeek h AbsoluteSeek offs
                          L.hGet h (fromInteger size)
                  )
-  dgs <- liftIO $ D.digest bs
-  return (dgs == digest inf)
+  return (D.digest bs == digest inf)
 
 -- | Create a MissingMap from a file handle and a piecemap. The system will read each part of
 --   the file and then check it against the digest. It will create a map of what we are missing

--- a/src/Process/Peer.hs
+++ b/src/Process/Peer.hs
@@ -781,7 +781,7 @@ allowedFast ip ihash sz n = generate n [] x []
             | p `elem` pcs = generate k pcs hsh rest
             | otherwise    = generate (k-1) (p : pcs) hsh rest
     generate k pcs hsh [] = do
-        nhsh <- Digest.digestBS hsh
+        let nhsh = Digest.digestBS hsh
         generate k pcs nhsh (genPieces nhsh)
 
     genPieces hash | B.null hash = []

--- a/src/Protocol/BCode.hs
+++ b/src/Protocol/BCode.hs
@@ -204,7 +204,7 @@ hashInfoDict bc =
                 Nothing -> fail "Could not find infoHash"
                 Just x  -> return x
        let encoded = encode ih
-       digest $ L.fromChunks $ [encoded]
+       return $ digest $ L.fromChunks $ [encoded]
 
 
 toPS :: String -> Path


### PR DESCRIPTION
Hi, the following pull request replace openssl by cryptohash. depending on openssl just for SHA1 is a bit heavyweight and for system where openssl is not available easily by default, make combinatorrent a bit hard to install. (disclaimer: i'm the author of cryptohash)
